### PR TITLE
Fix typo in container name

### DIFF
--- a/.dockerfunc
+++ b/.dockerfunc
@@ -421,7 +421,7 @@ nmap(){
 		jess/nmap "$@"
 }
 notify_osd(){
-	del_stopped notify-osd
+	del_stopped notify_osd
 
 	docker run -d \
 		-v /etc/machine-id:/etc/machine-id:ro \


### PR DESCRIPTION
Because of typo script is not capable of removing previously started container.

![container error](https://cloud.githubusercontent.com/assets/502493/11792477/948a08a8-a2a6-11e5-8200-72015b935775.png)
