### PR TITLE
repo() branch paths fixed

### DIFF
--- a/.functions
+++ b/.functions
@@ -228,7 +228,11 @@ repo() {
 		local giturl="http:${giturl}"
 
 		if [[ $gitbranch != "master" ]]; then
-			local giturl="${giturl}/tree/${gitbranch}"
+			if echo "${giturl}" | grep -i "bitbucket" > /dev/null ; then
+				local giturl="${giturl}/branch/${gitbranch}"
+                    	else
+                    		local giturl="${giturl}/tree/${gitbranch}"
+                    	fi
 		fi
 
 		echo $giturl


### PR DESCRIPTION
BitBucket has a different path for it's branches, so added a check. Works for github and bitbucket everywhere I've used.