### PR TITLE
Fix su-taking-ownership-of-index problem

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -20,9 +20,6 @@ prompt_git() {
 		# check if the current directory is in .git before running git checks
 		if [ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]; then
 
-			# Ensure the index is up to date.
-			git update-index --really-refresh -q &>/dev/null;
-
 			# Check for uncommitted changes in the index.
 			if ! $(git diff --quiet --ignore-submodules --cached); then
 				s+='+';


### PR DESCRIPTION
Hey Jess,

I completely jacked your git prompt and integrated it into my dotfiles, and I've been loving it. If you're curious, you can find the rest of my dotfiles [here](https://git.mpcsh.xyz/dotfiles.git). Anyways, I came across this issue a few times, where if you `su` inside of a git directory, `root` takes ownership of the `.git/index` file. When you drop back into your own shell, you get

> `fatal: .git/index: index file open failed: Permission denied`
`fatal: .git/index: index file open failed: Permission denied`
`fatal: .git/index: index file open failed: Permission denied`

before the prompt, and can't do any git operations until you `chown` the index. The root of this is the `git update-index` command on line 24. I can confirm that removing it doesn't affect normal use, and solves the ownership problem. Anyways, just thought I'd make you aware of this if you weren't already.