### PR TITLE
Restored git update-index functionality

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -20,6 +20,10 @@ prompt_git() {
 		# check if the current directory is in .git before running git checks
 		if [ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]; then
 
+			if [[ -O "$(git rev-parse --show-toplevel)/.git/index" ]]; then
+				git update-index --really-refresh -q &> /dev/null;
+			fi;
+
 			# Check for uncommitted changes in the index.
 			if ! $(git diff --quiet --ignore-submodules --cached); then
 				s+='+';


### PR DESCRIPTION
hey - so recently I've noticed that without that line I removed in #7 the prompt sometimes lags behind the actual git status (i.e. you need to hit enter for it to update). so I spent a few minutes combing through the git manpages (okay no, I lied, I spent 5 minutes on irc) finding a way to test if you own the git index. enjoy